### PR TITLE
database/migrations: allow nullable values for event_id column

### DIFF
--- a/database/migrations/2017_10_20_025837_connect_events_and_attendees.php
+++ b/database/migrations/2017_10_20_025837_connect_events_and_attendees.php
@@ -16,7 +16,7 @@ class ConnectEventsAndAttendees extends Migration
         Schema::table('attendees', function (Blueprint $table) {
 
             # Add a new INT field called `event_id` that has to be unsigned (i.e. positive)
-            $table->integer('event_id')->unsigned();
+            $table->integer('event_id')->unsigned()->nullable();
 
             # This field `event_id` is a foreign key that connects to the `id` field in the `events` table
             $table->foreign('event_id')->references('id')->on('events');


### PR DESCRIPTION
fixes migration error occurs when `DB_DATABASE=sqlite` 

`Cannot add a NOT NULL column with default value NULL (SQL: alter table "attendees" add column "event_id" integer not null)`
